### PR TITLE
feat: add multiplex support by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "libp2p-railing": "~0.4.1",
     "libp2p-secio": "~0.6.7",
     "libp2p-spdy": "~0.10.4",
-    "libp2p-swarm": "~0.26.17",
+    "libp2p-swarm": "~0.26.18",
     "libp2p-webrtc-star": "~0.8.8",
     "libp2p-websockets": "~0.9.2",
     "mafmt": "^2.1.6",

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   ],
   "scripts": {
     "lint": "aegir-lint",
-    "test": "gulp test",
+    "test": "gulp test --webworker false",
     "test:node": "gulp test:node",
     "test:browser": "gulp test:browser",
     "build": "gulp build",
-    "release": "gulp release",
-    "release-minor": "gulp release --type minor",
-    "release-major": "gulp release --type major",
+    "release": "gulp release --webworker false",
+    "release-minor": "gulp release --type minor --webworker false",
+    "release-major": "gulp release --type major --webworker false",
     "coverage": "gulp coverage",
     "coverage-publish": "aegir-coverage publish"
   },

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   ],
   "scripts": {
     "lint": "aegir-lint",
-    "test": "gulp test --webworker false",
+    "test": "gulp test --dom",
     "test:node": "gulp test:node",
-    "test:browser": "gulp test:browser",
+    "test:browser": "gulp test:browser --dom",
     "build": "gulp build",
-    "release": "gulp release --webworker false",
-    "release-minor": "gulp release --type minor --webworker false",
-    "release-major": "gulp release --type major --webworker false",
+    "release": "gulp release --dom",
+    "release-minor": "gulp release --type minor --dom",
+    "release-major": "gulp release --type major --dom",
     "coverage": "gulp coverage",
     "coverage-publish": "aegir-coverage publish"
   },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "libp2p": "~0.5.4",
+    "libp2p-multiplex": "^0.4.1",
     "libp2p-railing": "~0.4.1",
     "libp2p-secio": "~0.6.7",
     "libp2p-spdy": "~0.10.4",

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,30 @@ const secio = require('libp2p-secio')
 const Railing = require('libp2p-railing')
 const libp2p = require('libp2p')
 
+function mapMuxers (list) {
+  return list.map((pref) => {
+    if (typeof pref !== 'string') {
+      return pref
+    }
+    switch (pref.trim().toLowerCase()) {
+      case 'spdy':
+        return spdy
+      case 'multiplex':
+        return multiplex
+      default:
+        throw new Error(pref + ' muxer not available')
+    }
+  })
+}
+
+function getMuxers (options) {
+  if (options) {
+    return mapMuxers(options)
+  } else {
+    return [spdy, multiplex]
+  }
+}
+
 class Node extends libp2p {
   constructor (peerInfo, peerBook, options) {
     options = options || {}
@@ -19,7 +43,7 @@ class Node extends libp2p {
         webRTCStar
       ],
       connection: {
-        muxer: options.muxer || [spdy, multiplex],
+        muxer: getMuxers(options.muxer),
         crypto: [
           secio
         ]

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 const WS = require('libp2p-websockets')
 const WebRTCStar = require('libp2p-webrtc-star')
 const spdy = require('libp2p-spdy')
+const multiplex = require('libp2p-multiplex')
 const secio = require('libp2p-secio')
 const Railing = require('libp2p-railing')
 const libp2p = require('libp2p')
@@ -18,9 +19,7 @@ class Node extends libp2p {
         webRTCStar
       ],
       connection: {
-        muxer: [
-          spdy
-        ],
+        muxer: options.muxer || [spdy, multiplex],
         crypto: [
           secio
         ]

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ function getMuxers (options) {
   if (options) {
     return mapMuxers(options)
   } else {
-    return [spdy, multiplex]
+    return [multiplex, spdy]
   }
 }
 

--- a/test/websockets-only.js
+++ b/test/websockets-only.js
@@ -44,6 +44,17 @@ describe('libp2p-ipfs-browser (websockets only)', () => {
     })
   })
 
+  it('create libp2pNode with multiplex only', (done) => {
+    PeerInfo.create((err, info) => {
+      expect(err).to.not.exist
+      const b = new Node(info, null, {muxer: ['multiplex']})
+      expect(b.modules.connection.muxer).to.eql([
+        require('libp2p-multiplex')
+      ])
+      done()
+    })
+  })
+
   it('start libp2pNode', (done) => {
     nodeA.start(done)
   })


### PR DESCRIPTION
BREAKING CHANGE: Prefer `multiplex` over `spdy`, as it works better with go-ipfs

Closes #159 